### PR TITLE
add AVR CRD and CR samples

### DIFF
--- a/subscriptions/busybox/avr.yaml
+++ b/subscriptions/busybox/avr.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: ApplicationVolumeReplication
+metadata:
+  name: avr-test-for-busybox-subs
+  namespace: busybox-sample
+spec:
+  clusterPeersRef:
+    name: dr-peers-for-busybox-app
+    namespace: busybox-sample
+  placement:
+      placementRef:
+        kind: PlacementRule
+        name: busybox-placement
+  pvcSelector:
+    matchLabels:
+      appclass: gold
+      environment: dev.AZ1
+  s3Endpoint: path/to/s3Endpoint
+  s3Region: "us-west"
+  s3SecretName: SecretName
+  subscriptionSelector:
+    matchLabels:
+      app: busybox-sample

--- a/subscriptions/busybox/clusterpeers.yaml
+++ b/subscriptions/busybox/clusterpeers.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: ClusterPeers
+metadata:
+  name: dr-peers-for-busybox-app
+  namespace: busybox-sample
+spec:
+  clusterNames:
+  - east-cluster
+  - west-cluster
+  replicationPolicy: async


### PR DESCRIPTION
Added CRD and CR yaml file for AVR and ClusterPeers.
**Should the AVR CR be in a different namespace (i.e. ramen namespace) rather than app namespace?**