### PR TITLE
Remove S3 secret from app namespace

### DIFF
--- a/subscriptions/busybox/kustomization.yaml
+++ b/subscriptions/busybox/kustomization.yaml
@@ -1,5 +1,6 @@
 namespace: busybox-sample
 resources:
+- namespace.yaml
 - placementrule.yaml
 - subscription.yaml
 - drpc.yaml

--- a/subscriptions/busybox/namespace.yaml
+++ b/subscriptions/busybox/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: busybox-sample

--- a/subscriptions/busybox/s3secret.yaml
+++ b/subscriptions/busybox/s3secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: busybox-s3secret
-  labels:
-    app: busybox-sample
-stringData:
-  AWS_ACCESS_KEY_ID: "minio"
-  AWS_SECRET_ACCESS_KEY: "minio123"


### PR DESCRIPTION
This is admin controlled, and is configured by the
admin for the controller.

Also, add back the namespace creation to the application
samples as this was created prior in earlier cases to
store the s3 secret.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>