### PR TITLE
apply busybox-sample namespace to hub

### DIFF
--- a/subscriptions/busybox/kustomization.yaml
+++ b/subscriptions/busybox/kustomization.yaml
@@ -1,5 +1,6 @@
 namespace: busybox-sample
 resources:
+- namespace.yaml
 - placementrule.yaml
 - subscription.yaml
 - drpc.yaml

--- a/subscriptions/busybox/namespace.yaml
+++ b/subscriptions/busybox/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: busybox-sample


### PR DESCRIPTION
In 3-cluster configuration, i.e. a hub that is not a managed cluster and two managed clusters, sample application deployment fails because its namespace is no longer applied to the hub:
```
+ kubectl --context hub apply -k https://github.com/ramendr/ocm-ramen-samples/subscriptions/busybox?ref=main
Error from server (NotFound): error when creating "https://github.com/ramendr/ocm-ramen-samples/subscriptions/busybox?ref=main": namespaces "busybox-sample" not found
Error from server (NotFound): error when creating "https://github.com/ramendr/ocm-ramen-samples/subscriptions/busybox?ref=main": namespaces "busybox-sample" not found
Error from server (NotFound): error when creating "https://github.com/ramendr/ocm-ramen-samples/subscriptions/busybox?ref=main": namespaces "busybox-sample" not found
```
This changes restores namespace creation.  It is half of #8, which is dependent on https://github.com/RamenDR/ramen/pull/230 which has not yet been merged.