### PR TITLE
Add directory for busybox-odr to use the non default RBD storage class

### DIFF
--- a/busybox-mirror/busybox-pod.yaml
+++ b/busybox-mirror/busybox-pod.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    appname: busybox
+spec:
+  containers:
+    - name: busybox
+      image: quay.io/vcppds7878/busybox:latest 
+      imagePullPolicy: IfNotPresent
+      command: ['sh', '-c', 'while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 1; done']
+      volumeMounts:
+        - name: mypvc
+          mountPath: /mnt/test
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: busybox-pvc
+        readOnly: false

--- a/busybox-mirror/busybox-pvc.yaml
+++ b/busybox-mirror/busybox-pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: busybox-pvc
+  labels:
+    appname: busybox
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: ocs-storagecluster-ceph-rbdmirror
+  resources:
+    requests:
+      storage: 5Gi

--- a/busybox-mirror/kustomization.yaml
+++ b/busybox-mirror/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+resources:
+- busybox-pvc.yaml
+- busybox-pod.yaml


### PR DESCRIPTION
This busybox example will use the ocs-storagecluster-ceph-rbdmirror storage class so we do not have to modify the default RBD storage class.