### PR TITLE
Add static label to PVC

### DIFF
--- a/busybox-odr-metro/busybox-pvc.yaml
+++ b/busybox-odr-metro/busybox-pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: busybox-pvc
   labels:
     appname: busybox
+    placement: busybox-placement-1
 spec:
   accessModes:
   - ReadWriteOnce

--- a/busybox-odr/busybox-pvc.yaml
+++ b/busybox-odr/busybox-pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: busybox-pvc
   labels:
     appname: busybox
+    placement: busybox-placement-1
 spec:
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
The VolumeReplication won't be created because the ramen-dr-cluster-operator can't find a PersistantVolumeClaim with the expected labels. These labels are created by default via the WebUI

```
oc logs ramen-dr-cluster-operator-7df86d979f-jpxq2 -n openshift-dr-system | grep "Found 0 PVCs using label selector" | tail -1
Defaulted container "manager" out of: manager, kube-rbac-proxy
1.6650950424066994e+09	INFO	controllers.VolumeReplicationGroup	controllers/volumereplicationgroup_controller.go:530	Found 0 PVCs using label selector app.kubernetes.io/created-by notin (volsync),placement=busybox-placement-1	{"VolumeReplicationGroup": "busybox-sample/busybox-placement-1-drpc"}
```