### PR TITLE
Avoids delay when terminating the busybox pod

### DIFF
--- a/busybox-odr-metro/busybox-pod.yaml
+++ b/busybox-odr-metro/busybox-pod.yaml
@@ -12,9 +12,9 @@ spec:
       type: RuntimeDefault
   containers:
     - name: busybox
-      image: quay.io/vcppds7878/busybox:latest 
+      image: quay.io/vcppds7878/busybox:latest
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 1; done']
+      command: ['sh', '-c', 'trap exit TERM; while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 1; done']
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/busybox-odr/busybox-pod.yaml
+++ b/busybox-odr/busybox-pod.yaml
@@ -12,9 +12,9 @@ spec:
       type: RuntimeDefault
   containers:
     - name: busybox
-      image: quay.io/vcppds7878/busybox:latest 
+      image: quay.io/vcppds7878/busybox:latest
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 1; done']
+      command: ['sh', '-c', 'trap exit TERM; while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 1; done']
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/busybox/busybox-pod.yaml
+++ b/busybox/busybox-pod.yaml
@@ -10,7 +10,7 @@ spec:
     - name: busybox
       image: busybox
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 10; done']
+      command: ['sh', '-c', 'trap exit TERM; while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 10 & wait; done']
       volumeMounts:
         - name: mypvc
           mountPath: /mnt/test


### PR DESCRIPTION
Without trapping SIGTERM, the signal will be ignored, and the pod will continue to run in Terminating state for 30 seconds.

Trapping SIGTERM is not enough; when sleeping 10 seconds, busybox sh will wait until the sleep command completes before handling the signal. We can avoid this delay by running sleep in the background and waiting for it.

Same fix applied to Reman test example here:
https://github.com/RamenDR/ramen/pull/667