### PR TITLE
Update channel.yaml

### DIFF
--- a/subscriptions/channel.yaml
+++ b/subscriptions/channel.yaml
@@ -3,6 +3,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
   name: ramen-gitops
+  namespace: ramen-samples
 spec:
   type: GitHub
   pathname: https://github.com/RamenDR/ocm-ramen-samples.git


### PR DESCRIPTION
Add the namespace to the channel definition. 

This is to keep the behavior same with the kustomize usage. When we use the kustomization.yaml file in this dir, we get the channel created in the right namespace as the kustomization file mentions it.