### PR TITLE
Use busybox image from quay.io

### DIFF
--- a/busybox/busybox-deployment.yaml
+++ b/busybox/busybox-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         appname: busybox
     spec:
       containers:
-      - image: docker.io/library/busybox:stable
+      - image: quay.io/nirsof/busybox:stable
         imagePullPolicy: IfNotPresent
         name: busybox
         command: ['sh', '-c', 'trap exit TERM; while true; do echo $(date) | tee -a /mnt/test/outfile; sync; sleep 10 & wait; done']


### PR DESCRIPTION
Use the same image used in ramen test infrastructure to avoid rate limiting in dockerhub.