### PR TITLE
Add DataVolume and DataVolumeTemplate kubevirt samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Kubernetes and OpenShift.
 - kubevirt
   - vm-pvc - PVC based VM
   - vm-dv - DataVolume based VM
+  - vm-dvt - DataVolumeTemplate based VM
 
 ## Deploying a sample application
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Kubernetes and OpenShift.
 - deployment - busybox deployment
 - kubevirt
   - vm-pvc - PVC based VM
+  - vm-dv - DataVolume based VM
 
 ## Deploying a sample application
 

--- a/dr/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+  - ../base
+namespace: vm-dv
+commonLabels:
+  app: vm-dv

--- a/dr/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+  - ../base
+namespace: vm-dvt
+commonLabels:
+  app: vm-dvt

--- a/subscription/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../../base
+namespace: vm-dv
+commonLabels:
+  app: vm-dv
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/vm-dv/k8s-regional

--- a/subscription/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../../base
+namespace: vm-dvt
+commonLabels:
+  app: vm-dvt
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/vm-dvt/k8s-regional

--- a/workloads/kubevirt/vm-dv/base/dv.yaml
+++ b/workloads/kubevirt/vm-dv/base/dv.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: root-disk
+spec:
+  storage:
+    accessModes:
+      - ReadWriteMany
+    # Customize in your overlay.
+    storageClassName: STORAGE_CLASS_NAME
+    resources:
+      requests:
+        storage: 128Mi
+  source:
+    registry:
+      url: "docker://quay.io/nirsof/cirros:0.6.2-1"

--- a/workloads/kubevirt/vm-dv/base/kustomization.yaml
+++ b/workloads/kubevirt/vm-dv/base/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+resources:
+  - vm.yaml
+  - dv.yaml
+commonLabels:
+  appname: vm
+secretGenerator:
+  - name: my-public-key
+    files:
+      - test_rsa.pub
+generatorOptions:
+  disableNameSuffixHash: true

--- a/workloads/kubevirt/vm-dv/base/test_rsa.pub
+++ b/workloads/kubevirt/vm-dv/base/test_rsa.pub
@@ -1,0 +1,1 @@
+replace this text with your public key contents

--- a/workloads/kubevirt/vm-dv/base/vm.yaml
+++ b/workloads/kubevirt/vm-dv/base/vm.yaml
@@ -1,0 +1,49 @@
+# PVC based test vm.
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: vm
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: root-disk
+              disk:
+                bus: virtio
+            - name: cloud-init
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              model: virtio
+        resources:
+          requests:
+            # See https://github.com/cirros-dev/cirros/issues/53
+            memory: 256Mi
+      networks:
+        - name: default
+          pod: {}
+      accessCredentials:
+        - sshPublicKey:
+            source:
+              secret:
+                secretName: my-public-key
+            propagationMethod:
+              configDrive: {}
+      volumes:
+        - name: root-disk
+          persistentVolumeClaim:
+            claimName: root-disk
+        - name: cloud-init
+          cloudInitConfigDrive:
+            userData: |
+              #!/bin/sh
+              echo "Running user-data script"

--- a/workloads/kubevirt/vm-dv/k8s-regional/kustomization.yaml
+++ b/workloads/kubevirt/vm-dv/k8s-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for Ramen test enviroment.
+---
+resources:
+  - ../base
+patches:
+  # Use bridge network interface, required for minikube.
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/bridge
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: DataVolume
+      name: root-disk
+    patch: |-
+      - op: replace
+        path: /spec/storage/storageClassName
+        value: rook-ceph-block

--- a/workloads/kubevirt/vm-dv/odr-metro/kustomization.yaml
+++ b/workloads/kubevirt/vm-dv/odr-metro/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for OpenShift Metro DR environment.
+---
+resources:
+  - ../base
+patches:
+  # Use masquerade network interface.
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+  # Use external ceph cluster.
+  - target:
+      kind: DataVolume
+      name: root-disk
+    patch: |-
+      - op: replace
+        path: /spec/storage/storageClassName
+        value: ocs-external-storagecluster-ceph-rbd

--- a/workloads/kubevirt/vm-dv/odr-regional/kustomization.yaml
+++ b/workloads/kubevirt/vm-dv/odr-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for OpenShift Regional DR environment.
+---
+resources:
+  - ../base
+patches:
+  # Use masquerade network interface.
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: DataVolume
+      name: root-disk
+    patch: |-
+      - op: replace
+        path: /spec/storage/storageClassName
+        value: ocs-storagecluster-ceph-rbd

--- a/workloads/kubevirt/vm-dvt/base/kustomization.yaml
+++ b/workloads/kubevirt/vm-dvt/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+resources:
+  - vm.yaml
+commonLabels:
+  appname: vm
+secretGenerator:
+  - name: my-public-key
+    files:
+      - test_rsa.pub
+generatorOptions:
+  disableNameSuffixHash: true

--- a/workloads/kubevirt/vm-dvt/base/test_rsa.pub
+++ b/workloads/kubevirt/vm-dvt/base/test_rsa.pub
@@ -1,0 +1,1 @@
+replace this text with your public key contents

--- a/workloads/kubevirt/vm-dvt/base/vm.yaml
+++ b/workloads/kubevirt/vm-dvt/base/vm.yaml
@@ -1,0 +1,68 @@
+# PVC based test vm.
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: vm
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: root-disk
+              disk:
+                bus: virtio
+            - name: cloud-init
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              model: virtio
+        resources:
+          requests:
+            # See https://github.com/cirros-dev/cirros/issues/53
+            memory: 256Mi
+      networks:
+        - name: default
+          pod: {}
+      accessCredentials:
+        - sshPublicKey:
+            source:
+              secret:
+                secretName: my-public-key
+            propagationMethod:
+              configDrive: {}
+      volumes:
+        - name: root-disk
+          persistentVolumeClaim:
+            claimName: root-disk
+        - name: cloud-init
+          cloudInitConfigDrive:
+            userData: |
+              #!/bin/sh
+              echo "Running user-data script"
+  dataVolumeTemplates:
+    - metadata:
+        name: root-disk
+        annotations:
+          cdi.kubevirt.io/storage.checkStaticVolume: "true"
+        labels:
+          appname: vm
+      spec:
+        storage:
+          accessModes:
+            - ReadWriteMany
+          # Customize in your overlay.
+          storageClassName: STORAGE_CLASS_NAME
+          resources:
+            requests:
+              storage: 128Mi
+        source:
+          registry:
+            url: "docker://quay.io/nirsof/cirros:0.6.2-1"

--- a/workloads/kubevirt/vm-dvt/k8s-regional/kustomization.yaml
+++ b/workloads/kubevirt/vm-dvt/k8s-regional/kustomization.yaml
@@ -1,0 +1,17 @@
+# Kustomization for Ramen test enviroment.
+---
+resources:
+  - ../base
+patches:
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      # Use bridge network interface, required for minikube.
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/bridge
+        value: {}
+      # Use internal ceph cluster.
+      - op: replace
+        path: /spec/dataVolumeTemplates/0/spec/storage/storageClassName
+        value: rook-ceph-block

--- a/workloads/kubevirt/vm-dvt/odr-metro/kustomization.yaml
+++ b/workloads/kubevirt/vm-dvt/odr-metro/kustomization.yaml
@@ -1,0 +1,17 @@
+# Kustomization for OpenShift Metro DR environment.
+---
+resources:
+  - ../base
+patches:
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      # Use masquerade network interface.
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+      # Use external ceph cluster.
+      - op: replace
+        path: /spec/dataVolumeTemplates/0/spec/storage/storageClassName
+        value: ocs-external-storagecluster-ceph-rbd

--- a/workloads/kubevirt/vm-dvt/odr-regional/kustomization.yaml
+++ b/workloads/kubevirt/vm-dvt/odr-regional/kustomization.yaml
@@ -1,0 +1,17 @@
+# Kustomization for OpenShift Regional DR environment.
+---
+resources:
+  - ../base
+patches:
+  - target:
+      kind: VirtualMachine
+      name: vm
+    patch: |-
+      # Use masquerade network interface.
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+      # Use internal ceph cluster.
+      - op: replace
+        path: /spec/dataVolumeTemplates/0/spec/storage/storageClassName
+        value: ocs-storagecluster-ceph-rbd


### PR DESCRIPTION
Add new kubevirt samples:
- vm-dv - DataVolume based VM
- vm-dvt - DataVolumeTemplate based VM

Testing both requires kubevirt and CDI from git, since the required fixed are not available in the latest release.

I could not deploy yet latest kubevirt and CDI due to various issues, so I could not test the samples. They are based on the samples from Adam's repo:
https://github.com/aglitke/ocm-kubevirt-samples