### PR TITLE
Add kubevirt overlays for OpenShift Regional DR

### DIFF
--- a/subscription/kubevirt/base-odr/kustomization.yaml
+++ b/subscription/kubevirt/base-odr/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+resources:
+  - ../../base
+patches:
+  # You many need to modify based on the actual clusterset name.
+  - target:
+      kind: ManagedClusterSetBinding
+      name: default
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: submariner
+      - op: replace
+        path: /spec/clusterSet
+        value: submariner
+  # You many need to modify based on the actual clusterset name.
+  - target:
+      kind: Placement
+      name: placement
+    patch: |-
+      - op: replace
+        path: /spec/clusterSets/0
+        value: submariner

--- a/subscription/kubevirt/vm-dv-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dv-odr-regional/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base-odr
+namespace: vm-dv
+commonLabels:
+  app: vm-dv
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/vm-dv/odr-regional

--- a/subscription/kubevirt/vm-dvt-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dvt-odr-regional/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base-odr
+namespace: vm-dvt
+commonLabels:
+  app: vm-dvt
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/vm-dvt/odr-regional

--- a/subscription/kubevirt/vm-pvc-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-pvc-odr-regional/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+resources:
+  - ../base-odr
+namespace: vm-pvc
+commonLabels:
+  app: vm-pvc
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/vm-pvc/odr-regional


### PR DESCRIPTION
Add OpenShift subscription overlays for all sample VMs.

Notes:
- Assuming clusterset name `submariner`, what we typically use in the OCP test clusters. If you use another name, you need to modify the `subscription/kubevirt/base-odr` overlay.

Tested with https://github.com/RamenDR/ramen/pull/1288#issuecomment-2020633622