### PR TITLE
Add CephFS sample deployment

### DIFF
--- a/workloads/deployment/k8s-regional-cephfs/kustomization.yaml
+++ b/workloads/deployment/k8s-regional-cephfs/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+resources:
+  - ../base
+patches:
+  # Customize for internal cephfs storage.
+  - target:
+      kind: PersistentVolumeClaim
+      name: busybox-pvc
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: rook-cephfs
+      - op: replace
+        path: /spec/accessModes
+        value:
+          - ReadWriteMany


### PR DESCRIPTION
Can be used for testing OCM discovered application using CephFS storage. We will add subscription overlay later.

Missing:
- [ ] Document annotating the application namespace
  https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
- [ ] Document how to watch the vrg on the secondary cluster
- [ ] Document how to watch the volsync resources on both clusters
- [ ] Other differences compared with rbd?