### PR TITLE
Simplify disable DR to single step

### DIFF
--- a/workloads/kubevirt/README.md
+++ b/workloads/kubevirt/README.md
@@ -359,18 +359,16 @@ Delete the `dr` resources to disable DR:
 kubectl delete -k dr/kubevirt/vm-pvc-k8s-regional --context hub
 ```
 
-Enable *OCM* scheduling again by deleting the placement annotation we
-added before:
+At this point ramen is not protecting the virtual machine, and the
+storage used for replicating the virtual machine data on the DR clusters
+will be reclaimed.  The virtual machine will continue to run on the
+current cluster.
 
-```sh
-kubectl annotate placement placement \
-    cluster.open-cluster-management.io/experimental-scheduling-disable- \
-    --namespace vm-pvc \
-    --context hub
-```
-
-At this point *OCM* controls the VM and the storage used for replicating
-the VM data on the DR clusters will be reclaimed.
+> [!IMPORTANT]
+> Do not delete the Placement annotation
+> `cluster.open-cluster-management.io/experimental-scheduling-disable`
+> to ensure that OCM will not change the placement of the virtual
+> machine, which can result in data loss.
 
 ## Undeploying the VM
 


### PR DESCRIPTION
Previously we recommended to change the placement to point to the current cluster and enable OCM scheduling after disabling DR. This is risky and unneeded in most cases.

Change disable DR instructions to warn that the Placement annotation should not be removed, to ensure that OCM will not change the application placement.

Add optional section about enabling OCM scheduling, in case user have a reason to do this.

Related ramen changes:
- https://github.com/RamenDR/ramen/pull/1474

Part-of: https://github.com/RamenDR/ramen/issues/1441