### PR TITLE
Add demo VMs

### DIFF
--- a/dr/deployment-k8s-regional-rbd/kustomization.yaml
+++ b/dr/deployment-k8s-regional-rbd/kustomization.yaml
@@ -2,5 +2,6 @@
 resources:
   - ../base
 namespace: deployment-rbd
-commonLabels:
-  app: deployment-rbd
+labels:
+  - pairs:
+      app: deployment-rbd

--- a/dr/kubevirt/base/kustomization.yaml
+++ b/dr/kubevirt/base/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  appname: vm
+labels:
+  - pairs:
+      appname: vm
 patches:
   # Override appname to match our our label.
   - target:

--- a/dr/kubevirt/fedora-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/fedora-k8s-regional/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ../base
+namespace: fedora
+labels:
+  - pairs:
+      app: fedora

--- a/dr/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -2,5 +2,6 @@
 resources:
   - ../base
 namespace: vm-dv
-commonLabels:
-  app: vm-dv
+labels:
+  - pairs:
+      app: vm-dv

--- a/dr/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -2,5 +2,6 @@
 resources:
   - ../base
 namespace: vm-dvt
-commonLabels:
-  app: vm-dvt
+labels:
+  - pairs:
+      app: vm-dvt

--- a/dr/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
+++ b/dr/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
@@ -2,5 +2,6 @@
 resources:
   - ../base
 namespace: vm-pvc
-commonLabels:
-  app: vm-pvc
+labels:
+  - pairs:
+      app: vm-pvc

--- a/subscription/deployment-k8s-regional-rbd/kustomization.yaml
+++ b/subscription/deployment-k8s-regional-rbd/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../base
 namespace: deployment-rbd
-commonLabels:
-  app: deployment-rbd
+labels:
+  - pairs:
+      app: deployment-rbd
 patches:
   # Customize path to application.
   - target:

--- a/subscription/kubevirt/fedora-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/fedora-k8s-regional/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+resources:
+  - ../../base
+namespace: fedora
+labels:
+  - pairs:
+      app: fedora
+patches:
+  - target:
+      kind: Subscription
+      name: subscription
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/apps.open-cluster-management.io~1github-path
+        value: workloads/kubevirt/fedora/k8s-regional

--- a/subscription/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../../base
 namespace: vm-dv
-commonLabels:
-  app: vm-dv
+labels:
+  - pairs:
+      app: vm-dv
 patches:
   - target:
       kind: Subscription

--- a/subscription/kubevirt/vm-dv-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dv-odr-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../base-odr
 namespace: vm-dv
-commonLabels:
-  app: vm-dv
+labels:
+  - pairs:
+      app: vm-dv
 patches:
   - target:
       kind: Subscription

--- a/subscription/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../../base
 namespace: vm-dvt
-commonLabels:
-  app: vm-dvt
+labels:
+  - pairs:
+      app: vm-dvt
 patches:
   - target:
       kind: Subscription

--- a/subscription/kubevirt/vm-dvt-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-dvt-odr-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../base-odr
 namespace: vm-dvt
-commonLabels:
-  app: vm-dvt
+labels:
+  - pairs:
+      app: vm-dvt
 patches:
   - target:
       kind: Subscription

--- a/subscription/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../../base
 namespace: vm-pvc
-commonLabels:
-  app: vm-pvc
+labels:
+  - pairs:
+      app: vm-pvc
 patches:
   - target:
       kind: Subscription

--- a/subscription/kubevirt/vm-pvc-odr-regional/kustomization.yaml
+++ b/subscription/kubevirt/vm-pvc-odr-regional/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - ../base-odr
 namespace: vm-pvc
-commonLabels:
-  app: vm-pvc
+labels:
+  - pairs:
+      app: vm-pvc
 patches:
   - target:
       kind: Subscription

--- a/workloads/deployment/base/deployment.yaml
+++ b/workloads/deployment/base/deployment.yaml
@@ -7,11 +7,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      appname: busybox
+      part-of: busybox
   template:
     metadata:
       labels:
-        appname: busybox
+        part-of: busybox
     spec:
       containers:
         - name: logger

--- a/workloads/deployment/base/kustomization.yaml
+++ b/workloads/deployment/base/kustomization.yaml
@@ -2,5 +2,6 @@
 resources:
   - pvc.yaml
   - deployment.yaml
-commonLabels:
-  appname: busybox
+labels:
+  - pairs:
+      appname: busybox

--- a/workloads/kubevirt/fedora/base/config.yaml
+++ b/workloads/kubevirt/fedora/base/config.yaml
@@ -1,0 +1,11 @@
+# To inject the managed cluster name into the VM, create this config map in the
+# application namespace in all clusters before deploying the VM.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fedora
+data:
+  # Replace with the actual managed cluster name.
+  cluster: MANAGED_CLUSTER_NAME

--- a/workloads/kubevirt/fedora/base/kustomization.yaml
+++ b/workloads/kubevirt/fedora/base/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+resources:
+  - source.yaml
+  - pvc.yaml
+  - vm.yaml
+  - service.yaml
+labels:
+  - pairs:
+      appname: vm
+secretGenerator:
+  - name: fedora
+    files:
+      - test_rsa.pub
+generatorOptions:
+  disableNameSuffixHash: true

--- a/workloads/kubevirt/fedora/base/pvc.yaml
+++ b/workloads/kubevirt/fedora/base/pvc.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fedora
+spec:
+  dataSourceRef:
+    apiGroup: cdi.kubevirt.io
+    kind: VolumeImportSource
+    name: fedora
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 6Gi
+  # Customize in your overlay.
+  storageClassName: STORAGE_CLASS_NAME
+  volumeMode: Block

--- a/workloads/kubevirt/fedora/base/service.yaml
+++ b/workloads/kubevirt/fedora/base/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fedora
+spec:
+  ports:
+  - name: http
+    port: 8000
+    nodePort: 30080
+    protocol: TCP
+  selector:
+    kubevirt.io/domain: fedora
+  type: NodePort

--- a/workloads/kubevirt/fedora/base/source.yaml
+++ b/workloads/kubevirt/fedora/base/source.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: VolumeImportSource
+metadata:
+  name: fedora
+spec:
+  source:
+    registry:
+      url: "docker://quay.io/nirsof/dr-demo:fedora-6"

--- a/workloads/kubevirt/fedora/base/test_rsa.pub
+++ b/workloads/kubevirt/fedora/base/test_rsa.pub
@@ -1,0 +1,1 @@
+replace this text with your public key contents

--- a/workloads/kubevirt/fedora/base/vm.yaml
+++ b/workloads/kubevirt/fedora/base/vm.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: fedora
+    spec:
+      domain:
+        cpu:
+          cores:
+            2
+        devices:
+          disks:
+            - name: fedora
+              disk:
+                bus: virtio
+            - name: cloud-init
+              disk:
+                bus: virtio
+            - name: config
+              disk:
+                bus: virtio
+              serial: config-disk
+          interfaces:
+            - name: default
+              model: virtio
+        resources:
+          requests:
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      accessCredentials:
+        - sshPublicKey:
+            source:
+              secret:
+                secretName: fedora
+            propagationMethod:
+              noCloud: {}
+      volumes:
+        - name: fedora
+          persistentVolumeClaim:
+            claimName: fedora
+        - name: cloud-init
+          cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: fedora
+              chpasswd:
+                expire: false
+              bootcmd:
+                - "sudo mkdir -p /mnt/config"
+                - "sudo mount /dev/disk/by-id/virtio-config-disk /mnt/config"
+              runcmd:
+                - "sudo dnf install -y https://github.com/nirs/visitor/releases/download/v0.8.0/visitor-0.8.0-1.fc39.x86_64.rpm"
+                - "sudo systemctl enable visitor --now"
+        - name: config
+          configMap:
+            name: fedora
+            optional: true

--- a/workloads/kubevirt/fedora/container/Containerfile
+++ b/workloads/kubevirt/fedora/container/Containerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ADD fedora.qcow2 /disk/

--- a/workloads/kubevirt/fedora/container/Makefile
+++ b/workloads/kubevirt/fedora/container/Makefile
@@ -1,0 +1,15 @@
+VER := 6
+
+image := quay.io/nirsof/dr-demo:fedora-$(VER)
+
+container: fedora.qcow2
+	podman build -t $(image) .
+
+push:
+	podman push $(image)
+
+fedora.qcow2:
+	curl -L -o $@ https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2
+
+clean:
+	rm -f *.qcow2

--- a/workloads/kubevirt/fedora/k8s-regional/kustomization.yaml
+++ b/workloads/kubevirt/fedora/k8s-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for Ramen test enviroment.
+---
+resources:
+  - ../base
+patches:
+  # Use bridge network interface, required for minikube.
+  - target:
+      kind: VirtualMachine
+      name: fedora
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/bridge
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: PersistentVolumeClaim
+      name: fedora
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: rook-ceph-block

--- a/workloads/kubevirt/fedora/odr-regional/kustomization.yaml
+++ b/workloads/kubevirt/fedora/odr-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for OpenShift Regional DR environment.
+---
+resources:
+  - ../base
+patches:
+  # Use masquerade network interface.
+  - target:
+      kind: VirtualMachine
+      name: fedora
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: PersistentVolumeClaim
+      name: fedora
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: ocs-storagecluster-ceph-rbd-virtualization

--- a/workloads/kubevirt/vm-dv/base/kustomization.yaml
+++ b/workloads/kubevirt/vm-dv/base/kustomization.yaml
@@ -2,8 +2,9 @@
 resources:
   - vm.yaml
   - dv.yaml
-commonLabels:
-  appname: vm
+labels:
+  - pairs:
+      appname: vm
 secretGenerator:
   - name: my-public-key
     files:

--- a/workloads/kubevirt/vm-dv/base/vm.yaml
+++ b/workloads/kubevirt/vm-dv/base/vm.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-        kubevirt.io/size: small
+        kubevirt.io/size: tiny
         kubevirt.io/domain: vm
     spec:
       domain:

--- a/workloads/kubevirt/vm-dvt/base/kustomization.yaml
+++ b/workloads/kubevirt/vm-dvt/base/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - vm.yaml
-commonLabels:
-  appname: vm
+labels:
+  - pairs:
+      appname: vm
 secretGenerator:
   - name: my-public-key
     files:

--- a/workloads/kubevirt/vm-dvt/base/vm.yaml
+++ b/workloads/kubevirt/vm-dvt/base/vm.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-        kubevirt.io/size: small
+        kubevirt.io/size: tiny
         kubevirt.io/domain: vm
     spec:
       domain:

--- a/workloads/kubevirt/vm-pvc/base/kustomization.yaml
+++ b/workloads/kubevirt/vm-pvc/base/kustomization.yaml
@@ -3,8 +3,9 @@ resources:
   - source.yaml
   - pvc.yaml
   - vm.yaml
-commonLabels:
-  appname: vm
+labels:
+  - pairs:
+      appname: vm
 secretGenerator:
   - name: my-public-key
     files:

--- a/workloads/kubevirt/vm-pvc/base/vm.yaml
+++ b/workloads/kubevirt/vm-pvc/base/vm.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-        kubevirt.io/size: small
+        kubevirt.io/size: tiny
         kubevirt.io/domain: vm
     spec:
       domain:

--- a/workloads/kubevirt/win2k22/base/kustomization.yaml
+++ b/workloads/kubevirt/win2k22/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+resources:
+  - source.yaml
+  - pvc.yaml
+  - vm.yaml
+  - service.yaml
+labels:
+  - pairs:
+      appname: vm

--- a/workloads/kubevirt/win2k22/base/pvc.yaml
+++ b/workloads/kubevirt/win2k22/base/pvc.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: root-disk
+spec:
+  dataSourceRef:
+    apiGroup: cdi.kubevirt.io
+    kind: VolumeImportSource
+    name: win2k22-source
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 40Gi
+  # Customize in your overlay.
+  storageClassName: STORAGE_CLASS_NAME
+  volumeMode: Block

--- a/workloads/kubevirt/win2k22/base/service.yaml
+++ b/workloads/kubevirt/win2k22/base/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: win2k22-service
+spec:
+  ports:
+  - name: rdp
+    port: 3389
+    nodePort: 32689
+    protocol: TCP
+  - name: http
+    port: 8000
+    nodePort: 32680
+    protocol: TCP
+  selector:
+    kubevirt.io/domain: win2k22
+  type: NodePort

--- a/workloads/kubevirt/win2k22/base/source.yaml
+++ b/workloads/kubevirt/win2k22/base/source.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: VolumeImportSource
+metadata:
+  name: win2k22-source
+spec:
+  source:
+    registry:
+      # Replace with URL of a Windows container disk.
+      url: "docker://REGISTRY/REPO/IMAGE:TAG"

--- a/workloads/kubevirt/win2k22/base/vm.yaml
+++ b/workloads/kubevirt/win2k22/base/vm.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: win2k22
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: large
+        vm.kubevirt.io/os: windows2k22
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/size: large
+        kubevirt.io/domain: win2k22
+    spec:
+      domain:
+        cpu:
+          cores:
+            4
+        clock:
+          timer:
+            hpet:
+              present: false
+            hyperv: {}
+            pit:
+              tickPolicy: delay
+            rtc:
+              tickPolicy: catchup
+          utc: {}
+        features:
+          acpi: {}
+          apic: {}
+          hyperv:
+            frequencies: {}
+            ipi: {}
+            reenlightenment: {}
+            relaxed: {}
+            reset: {}
+            runtime: {}
+            spinlocks:
+              spinlocks: 8191
+            synic: {}
+            synictimer:
+              direct: {}
+            tlbflush: {}
+            vapic: {}
+            vpindex: {}
+          smm: {}
+        devices:
+          disks:
+            - name: root-disk
+              disk:
+                bus: virtio
+          inputs:
+            # Required for correct mouse tracking in VNC.
+            - bus: usb
+              name: tablet
+              type: tablet
+          interfaces:
+            - name: default
+              model: virtio
+        resources:
+          requests:
+            memory: 8Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: root-disk
+          persistentVolumeClaim:
+            claimName: root-disk

--- a/workloads/kubevirt/win2k22/k8s-regional/kustomization.yaml
+++ b/workloads/kubevirt/win2k22/k8s-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for Ramen test enviroment.
+---
+resources:
+  - ../base
+patches:
+  # Use bridge network interface, required for minikube.
+  - target:
+      kind: VirtualMachine
+      name: win2k22
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/bridge
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: PersistentVolumeClaim
+      name: root-disk
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: rook-ceph-block

--- a/workloads/kubevirt/win2k22/odr-regional/kustomization.yaml
+++ b/workloads/kubevirt/win2k22/odr-regional/kustomization.yaml
@@ -1,0 +1,21 @@
+# Kustomization for OpenShift Regional DR environment.
+---
+resources:
+  - ../base
+patches:
+  # Use masquerade network interface.
+  - target:
+      kind: VirtualMachine
+      name: win2k22
+    patch: |-
+      - op: add
+        path: /spec/template/spec/domain/devices/interfaces/0/masquerade
+        value: {}
+  # Use internal ceph cluster.
+  - target:
+      kind: PersistentVolumeClaim
+      name: root-disk
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: ocs-storagecluster-ceph-rbd-virtualization


### PR DESCRIPTION
Add demo VMs using more realistic VM configurations.

- Fedora 40 server with 2 cpus, 2g RAM, and 6g disk
- Windows server 2022 with 4 cpus, 8g RAM, and 40g disk
- Match VM size to kubevirt common templates
- Replace commonLabels with labels

The demo VMs include a demo web application showing how data is preserved in failover and relocate and the downtime during failover and relocate.

Example page after relocate:

![Screenshot from 2024-08-08 21-06-08](https://github.com/user-attachments/assets/a36b46f7-199a-43df-8082-22eddb2279bb)

Tested on drenv and OpenShift.