### PR TITLE
Add argocd appsets based application samples

### DIFF
--- a/applicationset/base/applicationset.yaml
+++ b/applicationset/base/applicationset.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: APPSET_NAME  # Replace in overlay with unique ApplicationSet name
+  namespace: argocd
+spec:
+  generators:
+  - clusterDecisionResource:
+      configMapRef: APPSET_NAME  # Replace in overlay with ApplicationSet name
+      labelSelector:
+        matchLabels:
+          cluster.open-cluster-management.io/placement: APPSET_NAME  # Replace in overlay with Placement name
+      requeueAfterSeconds: 180
+  template:
+    metadata:
+      name: 'UNIQUE_APP_NAME-{{name}}'  # Replace in overlay with application name pattern
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/RamenDR/ocm-ramen-samples.git
+        targetRevision: main
+        path: WORKLOAD_PATH  # Replace in overlay with workload source path
+      destination:
+        server: '{{server}}'
+        namespace: DESTINATION_NAMESPACE  # Replace in overlay with target namespace
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - PruneLast=true

--- a/applicationset/base/binding.yaml
+++ b/applicationset/base/binding.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default  # Binds to the 'default' ManagedClusterSet
+  namespace: argocd
+spec:
+  clusterSet: default  # Change this if your ManagedClusterSet has a different name
+

--- a/applicationset/base/configmap.yaml
+++ b/applicationset/base/configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: APPSET_NAME  # Replace in overlay with ApplicationSet name (must match)
+  namespace: argocd
+  labels:
+    cluster.open-cluster-management.io/placement: APPSET_NAME  # Replace in overlay with ApplicationSet name
+data:
+  # ConfigMap metadata required by ArgoCD clusterDecisionResource generator
+  apiVersion: "cluster.open-cluster-management.io/v1beta1"
+  kind: "placementdecisions"
+  statusListKey: "decisions"
+  matchKey: "clusterName"

--- a/applicationset/base/kustomization.yaml
+++ b/applicationset/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+  - applicationset.yaml
+  - placement.yaml
+  - configmap.yaml
+  - binding.yaml

--- a/applicationset/base/placement.yaml
+++ b/applicationset/base/placement.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: APPSET_NAME  # Replace in overlay with ApplicationSet name (must match)
+  namespace: argocd
+  labels:
+    cluster.open-cluster-management.io/placement: APPSET_NAME  # Replace in overlay with ApplicationSet name
+spec:
+  numberOfClusters: 1
+  clusterSets:
+    - default
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            name: dr1  # Default target cluster (can be overridden in overlay)

--- a/applicationset/deployment-k8s-regional-rbd/kustomization.yaml
+++ b/applicationset/deployment-k8s-regional-rbd/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../base
+commonLabels:
+  app: deployment-rbd
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: deployment-rbd-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: deployment-rbd-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: deployment-rbd-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/deployment/k8s-regional-rbd
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: deployment-rbd
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: deployment-rbd-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: deployment-rbd-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: deployment-rbd-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: deployment-rbd-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: deployment-rbd-appset

--- a/applicationset/deployment-k8s-regional-rbd/kustomization.yaml
+++ b/applicationset/deployment-k8s-regional-rbd/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../base
-commonLabels:
-  app: deployment-rbd
+labels:
+  - pairs:
+      app: deployment-rbd
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-dv-k8s
+labels:
+  - pairs:
+      app: vm-dv
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-dv-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dv-k8s-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-dv-k8s
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-k8s-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-dv-k8s-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-k8s-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-dv/k8s-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-dv-k8s
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-dv-k8s-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-k8s-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-k8s-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-k8s-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-k8s-appset

--- a/applicationset/kubevirt/vm-dv-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dv-odr-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-dv-odr
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-odr-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-dv-odr-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-odr-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-dv/odr-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-dv-odr
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-dv-odr-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-odr-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-odr-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-dv-odr-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dv-odr-appset

--- a/applicationset/kubevirt/vm-dv-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dv-odr-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-dv-odr
+labels:
+  - pairs:
+      app: vm-dv-odr
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-dvt-k8s
+labels:
+  - pairs:
+      app: vm-dvt
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dvt-k8s-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-dvt-k8s
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-k8s-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-dvt-k8s-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-k8s-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-dvt/k8s-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-dvt-k8s
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-dvt-k8s-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-k8s-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-k8s-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-k8s-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-k8s-appset

--- a/applicationset/kubevirt/vm-dvt-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dvt-odr-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-dvt-odr
+labels:
+  - pairs:
+      app: vm-dvt-odr
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-dvt-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-dvt-odr-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-dvt-odr
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-odr-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-dvt-odr-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-odr-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-dvt/odr-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-dvt-odr
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-dvt-odr-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-odr-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-odr-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-dvt-odr-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-dvt-odr-appset

--- a/applicationset/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-pvc-k8s
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-k8s-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-pvc-k8s-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-k8s-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-pvc/k8s-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-pvc-k8s
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-pvc-k8s-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-k8s-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-k8s-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-k8s-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-k8s-appset

--- a/applicationset/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-pvc-k8s-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-pvc-k8s
+labels:
+  - pairs:
+      app: vm-pvc
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-pvc-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-pvc-odr-regional/kustomization.yaml
@@ -1,8 +1,9 @@
 ---
 resources:
   - ../../base
-commonLabels:
-  app: vm-pvc-odr
+labels:
+  - pairs:
+      app: vm-pvc-odr
 patches:
   - target:
       kind: ApplicationSet

--- a/applicationset/kubevirt/vm-pvc-odr-regional/kustomization.yaml
+++ b/applicationset/kubevirt/vm-pvc-odr-regional/kustomization.yaml
@@ -1,0 +1,58 @@
+---
+resources:
+  - ../../base
+commonLabels:
+  app: vm-pvc-odr
+patches:
+  - target:
+      kind: ApplicationSet
+      name: APPSET_NAME
+    patch: |-
+      # ApplicationSet name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-odr-appset
+      # ConfigMap reference
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/configMapRef
+        value: vm-pvc-odr-appset
+      # Placement label selector
+      - op: replace
+        path: /spec/generators/0/clusterDecisionResource/labelSelector/matchLabels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-odr-appset
+      # Workload path
+      - op: replace
+        path: /spec/template/spec/source/path
+        value: workloads/kubevirt/vm-pvc/odr-regional
+      # Target namespace
+      - op: replace
+        path: /spec/template/spec/destination/namespace
+        value: vm-pvc-odr
+      # Application name template
+      - op: replace
+        path: /spec/template/metadata/name
+        value: vm-pvc-odr-appset-{{name}}
+  - target:
+      kind: Placement
+      name: APPSET_NAME
+    patch: |-
+      # Placement name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-odr-appset
+      # Placement label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-odr-appset
+  - target:
+      kind: ConfigMap
+      name: APPSET_NAME
+    patch: |-
+      # ConfigMap name
+      - op: replace
+        path: /metadata/name
+        value: vm-pvc-odr-appset
+      # ConfigMap label
+      - op: replace
+        path: /metadata/labels/cluster.open-cluster-management.io~1placement
+        value: vm-pvc-odr-appset


### PR DESCRIPTION
The PR adds argocd applicationsets based application samples.

**Testing Summary:**
Verified ApplicationSet functionality across all workload types:

Deployment workload: 
`kubectl apply -k applicationset/deployment-k8s-regional-rbd/`

KubeVirt VM workloads:
```
kubectl apply -k applicationset/kubevirt/vm-dv-k8s-regional/
kubectl apply -k applicationset/kubevirt/vm-dv-odr-regional/
kubectl apply -k applicationset/kubevirt/vm-dvt-k8s-regional/
kubectl apply -k applicationset/kubevirt/vm-dvt-odr-regional/
kubectl apply -k applicationset/kubevirt/vm-pvc-k8s-regional/
kubectl apply -k applicationset/kubevirt/vm-pvc-odr-regional/
```

Results:
- All ApplicationSet resources created successfully in argocd namespace
- ArgoCD Applications generated correctly for each workload type
- Placement successfully selected dr1 cluster using predicate-based targeting
- No deprecation warnings after updating from commonLabels to labels

**Steps followed for testing:**
1. Initial Setup
Ensured ArgoCD RBAC permissions for OCM integration by applying the required ClusterRole and ClusterRoleBinding.
Verified OCM hub cluster context was active
2. Applied the ApplicationSet Configuration
`kubectl apply -k applicationset/deployment-k8s-regional-rbd/`
3. Verified ApplicationSet Creation
`kubectl get applicationsets -n argocd`
Expected: deployment-rbd-appset should be listed
4. Checked Generated Applications
`kubectl get applications -n argocd`
Expected: deployment-rbd-appset-dr1 should be created and eventually show Synced status
5. Confirmed Workload Deployment on Target Cluster
`kubectl get pods -n deployment-rbd --context=dr1`
Expected: busybox pod should be running on the dr1 cluster
